### PR TITLE
feat: add stream_response_to for streaming API responses directly to …

### DIFF
--- a/datalab_sdk/__init__.py
+++ b/datalab_sdk/__init__.py
@@ -10,6 +10,7 @@ from .exceptions import DatalabError, DatalabAPIError, DatalabTimeoutError
 from .models import (
     ConversionResult,
     CreateDocumentResult,
+    FileResult,
     OCRResult,
     ConvertOptions,
     ExtractOptions,
@@ -36,6 +37,7 @@ __all__ = [
     "DatalabTimeoutError",
     "ConversionResult",
     "CreateDocumentResult",
+    "FileResult",
     "OCRResult",
     "ConvertOptions",
     "ExtractOptions",

--- a/datalab_sdk/client.py
+++ b/datalab_sdk/client.py
@@ -50,6 +50,21 @@ from datalab_sdk.models import (
 from datalab_sdk.settings import settings
 
 
+class _AsyncIterableReader:
+    """Adapts an async iterable of bytes into an async file-like object for ijson."""
+
+    def __init__(self, async_iterable):
+        self._iter = async_iterable.__aiter__()
+
+    async def read(self, n=-1):
+        if n == 0:
+            return b""
+        try:
+            return await self._iter.__anext__()
+        except StopAsyncIteration:
+            return b""
+
+
 class AsyncDatalabClient:
     """Asynchronous client for Datalab API"""
 
@@ -278,9 +293,10 @@ class AsyncDatalabClient:
                 success = None
                 error = None
 
-                async for prefix, event, value in ijson.parse_async(
+                tee_reader = _AsyncIterableReader(
                     self._tee_stream_to_file(resp.content, fd)
-                ):
+                )
+                async for prefix, event, value in ijson.parse_async(tee_reader):
                     if prefix == "status" and event == "string":
                         status = value
                     elif prefix == "success" and event == "boolean":

--- a/datalab_sdk/client.py
+++ b/datalab_sdk/client.py
@@ -456,7 +456,8 @@ class AsyncDatalabClient:
         resolved_stream_response_to = None
         if stream_response_to:
             resolved_stream_response_to = Path(stream_response_to)
-            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+            if not resolved_stream_response_to.parent.is_dir():
+                raise ValueError(f"Directory does not exist: {resolved_stream_response_to.parent}")
 
         if options is None:
             options = ConvertOptions()
@@ -515,7 +516,8 @@ class AsyncDatalabClient:
         resolved_stream_response_to = None
         if stream_response_to:
             resolved_stream_response_to = Path(stream_response_to)
-            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+            if not resolved_stream_response_to.parent.is_dir():
+                raise ValueError(f"Directory does not exist: {resolved_stream_response_to.parent}")
 
         if options is None:
             raise ValueError("options must be provided with page_schema")
@@ -581,7 +583,8 @@ class AsyncDatalabClient:
         resolved_stream_response_to = None
         if stream_response_to:
             resolved_stream_response_to = Path(stream_response_to)
-            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+            if not resolved_stream_response_to.parent.is_dir():
+                raise ValueError(f"Directory does not exist: {resolved_stream_response_to.parent}")
 
         if options is None:
             raise ValueError("options must be provided with segmentation_schema")
@@ -644,7 +647,8 @@ class AsyncDatalabClient:
         resolved_stream_response_to = None
         if stream_response_to:
             resolved_stream_response_to = Path(stream_response_to)
-            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+            if not resolved_stream_response_to.parent.is_dir():
+                raise ValueError(f"Directory does not exist: {resolved_stream_response_to.parent}")
 
         if options is None:
             raise ValueError("options must be provided with pipeline_id")
@@ -699,7 +703,8 @@ class AsyncDatalabClient:
         resolved_stream_response_to = None
         if stream_response_to:
             resolved_stream_response_to = Path(stream_response_to)
-            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+            if not resolved_stream_response_to.parent.is_dir():
+                raise ValueError(f"Directory does not exist: {resolved_stream_response_to.parent}")
 
         if options is None:
             options = TrackChangesOptions()
@@ -759,7 +764,8 @@ class AsyncDatalabClient:
         resolved_stream_response_to = None
         if stream_response_to:
             resolved_stream_response_to = Path(stream_response_to)
-            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+            if not resolved_stream_response_to.parent.is_dir():
+                raise ValueError(f"Directory does not exist: {resolved_stream_response_to.parent}")
 
         payload = {
             "markdown": markdown,
@@ -827,7 +833,8 @@ class AsyncDatalabClient:
         resolved_stream_response_to = None
         if stream_response_to:
             resolved_stream_response_to = Path(stream_response_to)
-            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+            if not resolved_stream_response_to.parent.is_dir():
+                raise ValueError(f"Directory does not exist: {resolved_stream_response_to.parent}")
 
         warnings.warn(
             "The ocr() method is deprecated and will be removed in a future version. "
@@ -904,7 +911,8 @@ class AsyncDatalabClient:
         resolved_stream_response_to = None
         if stream_response_to:
             resolved_stream_response_to = Path(stream_response_to)
-            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+            if not resolved_stream_response_to.parent.is_dir():
+                raise ValueError(f"Directory does not exist: {resolved_stream_response_to.parent}")
 
         if options is None:
             raise ValueError("options must be provided with field_data")

--- a/datalab_sdk/client.py
+++ b/datalab_sdk/client.py
@@ -4,8 +4,13 @@ Datalab API client - async core with sync wrapper
 
 import asyncio
 import mimetypes
+import os
+import shutil
+import tempfile
 import warnings
+
 import aiohttp
+import ijson
 from tenacity import (
     retry,
     retry_if_exception,
@@ -25,6 +30,7 @@ from datalab_sdk.mimetypes import MIMETYPE_MAP
 from datalab_sdk.models import (
     ConversionResult,
     CreateDocumentResult,
+    FileResult,
     OCRResult,
     ProcessingOptions,
     ConvertOptions,
@@ -150,8 +156,12 @@ class AsyncDatalabClient:
         return await self._make_request("POST", endpoint, **kwargs)
 
     async def _poll_result(
-        self, check_url: str, max_polls: int = 300, poll_interval: int = 1
-    ) -> Dict[str, Any]:
+        self,
+        check_url: str,
+        max_polls: int = 300,
+        poll_interval: int = 1,
+        stream_response_to: Optional[Path] = None,
+    ) -> Union[Dict[str, Any], FileResult]:
         """Poll for result completion"""
         full_url = (
             check_url
@@ -160,14 +170,21 @@ class AsyncDatalabClient:
         )
 
         for i in range(max_polls):
-            data = await self._poll_get_with_retry(full_url)
+            if stream_response_to:
+                result = await self._poll_get_streaming(full_url, stream_response_to)
+                status, success, error = result.status, result.success, result.error
+            else:
+                data = await self._poll_get_with_retry(full_url)
+                status = data.get("status")
+                success = data.get("success", True)
+                error = data.get("error")
 
-            if data.get("status") == "complete":
-                return data
+            if status == "complete":
+                return result if stream_response_to else data
 
-            if not data.get("success", True) and not data.get("status") == "processing":
+            if not success and status != "processing":
                 raise DatalabAPIError(
-                    f"Processing failed: {data.get('error', 'Unknown error')}"
+                    f"Processing failed: {error or 'Unknown error'}"
                 )
 
             await asyncio.sleep(poll_interval)
@@ -201,6 +218,115 @@ class AsyncDatalabClient:
     async def _poll_get_with_retry(self, url: str) -> Dict[str, Any]:
         """GET wrapper for polling with scoped retries for transient failures"""
         return await self._make_request("GET", url)
+
+    @staticmethod
+    async def _tee_stream_to_file(content, fd):
+        """Async generator that writes each chunk to fd and yields it for ijson."""
+        async for chunk in content.iter_any():
+            os.write(fd, chunk)
+            yield chunk
+
+    @retry(
+        retry=(
+            retry_if_exception_type(DatalabTimeoutError)
+            | retry_if_exception(
+                lambda e: isinstance(e, DatalabAPIError)
+                and (
+                    getattr(e, "status_code", None) in (408, 429)
+                    or (
+                        getattr(e, "status_code", None) is not None
+                        and getattr(e, "status_code") >= 500
+                    )
+                    or getattr(e, "status_code", None) is None
+                )
+            )
+        ),
+        stop=stop_after_attempt(10),
+        wait=wait_exponential_jitter(initial=5, max=120),
+        reraise=True,
+    )
+    async def _poll_get_streaming(self, url: str, stream_response_to: Path) -> FileResult:
+        """GET with streaming to disk. Extracts status/success/error via ijson."""
+        await self._ensure_session()
+
+        fd = None
+        tmp_path = None
+        try:
+            fd, tmp_path = tempfile.mkstemp()
+
+            try:
+                resp = await self._session.get(url)
+            except asyncio.TimeoutError:
+                raise DatalabTimeoutError(f"Request timed out after {self.timeout} seconds")
+            except aiohttp.ClientError as e:
+                raise DatalabAPIError(f"Request failed: {str(e)}")
+
+            try:
+                if resp.status >= 400:
+                    body = await resp.read()
+                    try:
+                        import json as _json
+                        error_data = _json.loads(body)
+                        error_message = (
+                            error_data.get("detail") or error_data.get("error") or str(resp.status)
+                        )
+                    except Exception:
+                        error_message = f"HTTP {resp.status}"
+                    raise DatalabAPIError(error_message, resp.status)
+
+                status = None
+                success = None
+                error = None
+
+                async for prefix, event, value in ijson.parse_async(
+                    self._tee_stream_to_file(resp.content, fd)
+                ):
+                    if prefix == "status" and event == "string":
+                        status = value
+                    elif prefix == "success" and event == "boolean":
+                        success = value
+                    elif prefix == "error" and event in ("string", "null"):
+                        error = value
+            finally:
+                resp.release()
+
+            if status is None:
+                raise DatalabAPIError("Response missing 'status' field")
+
+            if success is None:
+                success = True
+
+            # Close fd before moving
+            os.close(fd)
+            fd = None
+
+            if status == "complete":
+                shutil.move(tmp_path, stream_response_to)
+                tmp_path = None
+                return FileResult(
+                    success=success,
+                    status=status,
+                    output_path=stream_response_to,
+                    error=error,
+                )
+            else:
+                return FileResult(
+                    success=success,
+                    status=status,
+                    output_path=stream_response_to,
+                    error=error,
+                )
+        finally:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
 
     def _prepare_file_data(self, file_path: Union[str, Path]) -> tuple:
         """Prepare file data for upload"""
@@ -284,7 +410,8 @@ class AsyncDatalabClient:
         data: aiohttp.FormData,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> Dict[str, Any]:
+        stream_response_to: Optional[Path] = None,
+    ) -> Union[Dict[str, Any], FileResult]:
         """Submit a request and poll for the result"""
         initial_data = await self._submit_with_retry(endpoint, data=data)
 
@@ -297,6 +424,7 @@ class AsyncDatalabClient:
             initial_data["request_check_url"],
             max_polls=max_polls,
             poll_interval=poll_interval,
+            stream_response_to=stream_response_to,
         )
 
     # Convenient endpoint-specific methods
@@ -306,9 +434,10 @@ class AsyncDatalabClient:
         file_url: Optional[str] = None,
         options: Optional[ConvertOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> ConversionResult:
+    ) -> Union[ConversionResult, FileResult]:
         """
         Convert a document to markdown, HTML, JSON, or chunks
 
@@ -317,9 +446,18 @@ class AsyncDatalabClient:
             file_url: URL of the file to convert
             options: Processing options for conversion
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
+        if save_output and stream_response_to:
+            raise ValueError("Cannot use both 'save_output' and 'stream_response_to'.")
+
+        resolved_stream_response_to = None
+        if stream_response_to:
+            resolved_stream_response_to = Path(stream_response_to)
+            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+
         if options is None:
             options = ConvertOptions()
 
@@ -330,7 +468,11 @@ class AsyncDatalabClient:
             ),
             max_polls=max_polls,
             poll_interval=poll_interval,
+            stream_response_to=resolved_stream_response_to,
         )
+
+        if isinstance(result_data, FileResult):
+            return result_data
 
         result = self._build_conversion_result(result_data, options.output_format)
 
@@ -348,9 +490,10 @@ class AsyncDatalabClient:
         file_url: Optional[str] = None,
         options: Optional[ExtractOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> ConversionResult:
+    ) -> Union[ConversionResult, FileResult]:
         """
         Extract structured data from a document using a JSON schema
 
@@ -362,9 +505,18 @@ class AsyncDatalabClient:
             file_url: URL of the file to extract from
             options: Extraction options (must include page_schema)
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
+        if save_output and stream_response_to:
+            raise ValueError("Cannot use both 'save_output' and 'stream_response_to'.")
+
+        resolved_stream_response_to = None
+        if stream_response_to:
+            resolved_stream_response_to = Path(stream_response_to)
+            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+
         if options is None:
             raise ValueError("options must be provided with page_schema")
 
@@ -383,7 +535,11 @@ class AsyncDatalabClient:
             ),
             max_polls=max_polls,
             poll_interval=poll_interval,
+            stream_response_to=resolved_stream_response_to,
         )
+
+        if isinstance(result_data, FileResult):
+            return result_data
 
         result = self._build_conversion_result(result_data, options.output_format)
 
@@ -400,9 +556,10 @@ class AsyncDatalabClient:
         file_url: Optional[str] = None,
         options: Optional[SegmentOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> ConversionResult:
+    ) -> Union[ConversionResult, FileResult]:
         """
         Segment a document into sections using a schema
 
@@ -414,9 +571,18 @@ class AsyncDatalabClient:
             file_url: URL of the file to segment
             options: Segmentation options (must include segmentation_schema)
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
+        if save_output and stream_response_to:
+            raise ValueError("Cannot use both 'save_output' and 'stream_response_to'.")
+
+        resolved_stream_response_to = None
+        if stream_response_to:
+            resolved_stream_response_to = Path(stream_response_to)
+            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+
         if options is None:
             raise ValueError("options must be provided with segmentation_schema")
 
@@ -435,7 +601,11 @@ class AsyncDatalabClient:
             ),
             max_polls=max_polls,
             poll_interval=poll_interval,
+            stream_response_to=resolved_stream_response_to,
         )
+
+        if isinstance(result_data, FileResult):
+            return result_data
 
         result = self._build_conversion_result(result_data, "markdown")
 
@@ -452,9 +622,10 @@ class AsyncDatalabClient:
         file_url: Optional[str] = None,
         options: Optional[CustomPipelineOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> ConversionResult:
+    ) -> Union[ConversionResult, FileResult]:
         """
         Execute a custom pipeline configuration
 
@@ -463,9 +634,18 @@ class AsyncDatalabClient:
             file_url: URL of the file to process
             options: Custom pipeline options (must include pipeline_id)
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
+        if save_output and stream_response_to:
+            raise ValueError("Cannot use both 'save_output' and 'stream_response_to'.")
+
+        resolved_stream_response_to = None
+        if stream_response_to:
+            resolved_stream_response_to = Path(stream_response_to)
+            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+
         if options is None:
             raise ValueError("options must be provided with pipeline_id")
 
@@ -476,7 +656,11 @@ class AsyncDatalabClient:
             ),
             max_polls=max_polls,
             poll_interval=poll_interval,
+            stream_response_to=resolved_stream_response_to,
         )
+
+        if isinstance(result_data, FileResult):
+            return result_data
 
         result = self._build_conversion_result(result_data, options.output_format)
 
@@ -493,9 +677,10 @@ class AsyncDatalabClient:
         file_url: Optional[str] = None,
         options: Optional[TrackChangesOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> ConversionResult:
+    ) -> Union[ConversionResult, FileResult]:
         """
         Extract and display tracked changes from DOCX documents
 
@@ -504,9 +689,18 @@ class AsyncDatalabClient:
             file_url: URL of the DOCX file
             options: Track changes options
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
+        if save_output and stream_response_to:
+            raise ValueError("Cannot use both 'save_output' and 'stream_response_to'.")
+
+        resolved_stream_response_to = None
+        if stream_response_to:
+            resolved_stream_response_to = Path(stream_response_to)
+            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+
         if options is None:
             options = TrackChangesOptions()
 
@@ -517,7 +711,11 @@ class AsyncDatalabClient:
             ),
             max_polls=max_polls,
             poll_interval=poll_interval,
+            stream_response_to=resolved_stream_response_to,
         )
+
+        if isinstance(result_data, FileResult):
+            return result_data
 
         result = self._build_conversion_result(result_data, options.output_format)
 
@@ -534,9 +732,10 @@ class AsyncDatalabClient:
         output_format: str = "docx",
         webhook_url: Optional[str] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> CreateDocumentResult:
+    ) -> Union[CreateDocumentResult, FileResult]:
         """
         Create a DOCX document from markdown with track changes support
 
@@ -550,9 +749,18 @@ class AsyncDatalabClient:
             output_format: Output format (currently only 'docx')
             webhook_url: Optional webhook URL for completion notification
             save_output: Optional path to save the output file
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
+        if save_output and stream_response_to:
+            raise ValueError("Cannot use both 'save_output' and 'stream_response_to'.")
+
+        resolved_stream_response_to = None
+        if stream_response_to:
+            resolved_stream_response_to = Path(stream_response_to)
+            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+
         payload = {
             "markdown": markdown,
             "output_format": output_format,
@@ -574,7 +782,11 @@ class AsyncDatalabClient:
             initial_data["request_check_url"],
             max_polls=max_polls,
             poll_interval=poll_interval,
+            stream_response_to=resolved_stream_response_to,
         )
+
+        if isinstance(result_data, FileResult):
+            return result_data
 
         result = CreateDocumentResult(
             status=result_data.get("status", "complete"),
@@ -600,14 +812,23 @@ class AsyncDatalabClient:
         file_path: Union[str, Path],
         options: Optional[ProcessingOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> OCRResult:
+    ) -> Union[OCRResult, FileResult]:
         """Perform OCR on a document
 
         .. deprecated::
             The /ocr endpoint is deprecated. Use convert() instead.
         """
+        if save_output and stream_response_to:
+            raise ValueError("Cannot use both 'save_output' and 'stream_response_to'.")
+
+        resolved_stream_response_to = None
+        if stream_response_to:
+            resolved_stream_response_to = Path(stream_response_to)
+            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+
         warnings.warn(
             "The ocr() method is deprecated and will be removed in a future version. "
             "Use convert() instead.",
@@ -631,7 +852,11 @@ class AsyncDatalabClient:
             initial_data["request_check_url"],
             max_polls=max_polls,
             poll_interval=poll_interval,
+            stream_response_to=resolved_stream_response_to,
         )
+
+        if isinstance(result_data, FileResult):
+            return result_data
 
         result = OCRResult(
             success=result_data.get("success", False),
@@ -657,9 +882,10 @@ class AsyncDatalabClient:
         file_url: Optional[str] = None,
         options: Optional[FormFillingOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> FormFillingResult:
+    ) -> Union[FormFillingResult, FileResult]:
         """
         Fill PDF or image forms with provided field data
 
@@ -668,9 +894,18 @@ class AsyncDatalabClient:
             file_url: URL of the file to fill
             options: Form filling options (must include field_data)
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
+        if save_output and stream_response_to:
+            raise ValueError("Cannot use both 'save_output' and 'stream_response_to'.")
+
+        resolved_stream_response_to = None
+        if stream_response_to:
+            resolved_stream_response_to = Path(stream_response_to)
+            resolved_stream_response_to.parent.mkdir(parents=True, exist_ok=True)
+
         if options is None:
             raise ValueError("options must be provided with field_data")
 
@@ -690,7 +925,11 @@ class AsyncDatalabClient:
             initial_data["request_check_url"],
             max_polls=max_polls,
             poll_interval=poll_interval,
+            stream_response_to=resolved_stream_response_to,
         )
+
+        if isinstance(result_data, FileResult):
+            return result_data
 
         result = FormFillingResult(
             status=result_data.get("status", "complete"),
@@ -1344,9 +1583,10 @@ class DatalabClient:
         file_url: Optional[str] = None,
         options: Optional[ConvertOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> ConversionResult:
+    ) -> Union[ConversionResult, FileResult]:
         """
         Convert a document to markdown, HTML, JSON, or chunks (sync version)
 
@@ -1355,6 +1595,7 @@ class DatalabClient:
             file_url: URL of the file to convert
             options: Processing options for conversion
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
@@ -1364,6 +1605,7 @@ class DatalabClient:
                 file_url=file_url,
                 options=options,
                 save_output=save_output,
+                stream_response_to=stream_response_to,
                 max_polls=max_polls,
                 poll_interval=poll_interval,
             )
@@ -1375,9 +1617,10 @@ class DatalabClient:
         file_url: Optional[str] = None,
         options: Optional[ExtractOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> ConversionResult:
+    ) -> Union[ConversionResult, FileResult]:
         """
         Extract structured data from a document using a JSON schema (sync version)
 
@@ -1386,6 +1629,7 @@ class DatalabClient:
             file_url: URL of the file to extract from
             options: Extraction options (must include page_schema)
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
@@ -1395,6 +1639,7 @@ class DatalabClient:
                 file_url=file_url,
                 options=options,
                 save_output=save_output,
+                stream_response_to=stream_response_to,
                 max_polls=max_polls,
                 poll_interval=poll_interval,
             )
@@ -1406,9 +1651,10 @@ class DatalabClient:
         file_url: Optional[str] = None,
         options: Optional[SegmentOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> ConversionResult:
+    ) -> Union[ConversionResult, FileResult]:
         """
         Segment a document into sections using a schema (sync version)
 
@@ -1417,6 +1663,7 @@ class DatalabClient:
             file_url: URL of the file to segment
             options: Segmentation options (must include segmentation_schema)
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
@@ -1426,6 +1673,7 @@ class DatalabClient:
                 file_url=file_url,
                 options=options,
                 save_output=save_output,
+                stream_response_to=stream_response_to,
                 max_polls=max_polls,
                 poll_interval=poll_interval,
             )
@@ -1437,9 +1685,10 @@ class DatalabClient:
         file_url: Optional[str] = None,
         options: Optional[CustomPipelineOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> ConversionResult:
+    ) -> Union[ConversionResult, FileResult]:
         """
         Execute a custom pipeline configuration (sync version)
 
@@ -1448,6 +1697,7 @@ class DatalabClient:
             file_url: URL of the file to process
             options: Custom pipeline options (must include pipeline_id)
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
@@ -1457,6 +1707,7 @@ class DatalabClient:
                 file_url=file_url,
                 options=options,
                 save_output=save_output,
+                stream_response_to=stream_response_to,
                 max_polls=max_polls,
                 poll_interval=poll_interval,
             )
@@ -1468,9 +1719,10 @@ class DatalabClient:
         file_url: Optional[str] = None,
         options: Optional[TrackChangesOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> ConversionResult:
+    ) -> Union[ConversionResult, FileResult]:
         """
         Extract and display tracked changes from DOCX documents (sync version)
 
@@ -1479,6 +1731,7 @@ class DatalabClient:
             file_url: URL of the DOCX file
             options: Track changes options
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
@@ -1488,6 +1741,7 @@ class DatalabClient:
                 file_url=file_url,
                 options=options,
                 save_output=save_output,
+                stream_response_to=stream_response_to,
                 max_polls=max_polls,
                 poll_interval=poll_interval,
             )
@@ -1499,9 +1753,10 @@ class DatalabClient:
         output_format: str = "docx",
         webhook_url: Optional[str] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> CreateDocumentResult:
+    ) -> Union[CreateDocumentResult, FileResult]:
         """
         Create a DOCX document from markdown (sync version)
 
@@ -1510,6 +1765,7 @@ class DatalabClient:
             output_format: Output format (currently only 'docx')
             webhook_url: Optional webhook URL for completion notification
             save_output: Optional path to save the output file
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
@@ -1519,6 +1775,7 @@ class DatalabClient:
                 output_format=output_format,
                 webhook_url=webhook_url,
                 save_output=save_output,
+                stream_response_to=stream_response_to,
                 max_polls=max_polls,
                 poll_interval=poll_interval,
             )
@@ -1529,9 +1786,10 @@ class DatalabClient:
         file_path: Union[str, Path],
         options: Optional[ProcessingOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> OCRResult:
+    ) -> Union[OCRResult, FileResult]:
         """Perform OCR on a document (sync version)
 
         .. deprecated::
@@ -1542,6 +1800,7 @@ class DatalabClient:
                 file_path=file_path,
                 options=options,
                 save_output=save_output,
+                stream_response_to=stream_response_to,
                 max_polls=max_polls,
                 poll_interval=poll_interval,
             )
@@ -1553,9 +1812,10 @@ class DatalabClient:
         file_url: Optional[str] = None,
         options: Optional[FormFillingOptions] = None,
         save_output: Optional[Union[str, Path]] = None,
+        stream_response_to: Optional[Union[str, Path]] = None,
         max_polls: int = 300,
         poll_interval: int = 1,
-    ) -> FormFillingResult:
+    ) -> Union[FormFillingResult, FileResult]:
         """
         Fill PDF or image forms with provided field data (sync version)
 
@@ -1564,6 +1824,7 @@ class DatalabClient:
             file_url: URL of the file to fill
             options: Form filling options (must include field_data)
             save_output: Optional path to save output files
+            stream_response_to: Optional path to stream raw JSON response to disk
             max_polls: Maximum number of polling attempts
             poll_interval: Seconds between polling attempts
         """
@@ -1573,6 +1834,7 @@ class DatalabClient:
                 file_url=file_url,
                 options=options,
                 save_output=save_output,
+                stream_response_to=stream_response_to,
                 max_polls=max_polls,
                 poll_interval=poll_interval,
             )

--- a/datalab_sdk/models.py
+++ b/datalab_sdk/models.py
@@ -498,3 +498,14 @@ class CreateDocumentResult:
 
         with open(output_path, "wb") as f:
             f.write(base64.b64decode(self.output_base64))
+
+
+@dataclass
+class FileResult:
+    """Lightweight result returned when stream_response_to is used.
+    The full JSON response is written directly to disk at output_path,
+    never fully loaded into memory."""
+    success: bool
+    status: str
+    output_path: Path
+    error: Optional[str] = None

--- a/integration/test_live_api.py
+++ b/integration/test_live_api.py
@@ -13,7 +13,7 @@ import json
 import pytest
 import os
 from pathlib import Path
-from datalab_sdk import DatalabClient, AsyncDatalabClient
+from datalab_sdk import DatalabClient, AsyncDatalabClient, FileResult
 from datalab_sdk.models import ConversionResult, OCRResult, ConvertOptions, OCROptions
 from datalab_sdk.exceptions import DatalabError
 
@@ -271,3 +271,104 @@ class TestSaveOutput:
         saved_json = json.loads((output_path.with_suffix(".ocr.json")).read_text())
         assert saved_json["success"] is True
         assert len(saved_json["pages"]) == len(result.pages)
+
+
+class TestStreamResponseTo:
+    """Test stream_response_to functionality with live API"""
+
+    def test_convert_stream_to_disk(self, tmp_path):
+        """Test that convert streams JSON response to disk and returns FileResult"""
+        client = DatalabClient()
+        pdf_file = DATA_DIR / "adversarial.pdf"
+        output_file = tmp_path / "result.json"
+
+        options = ConvertOptions(max_pages=1)
+        result = client.convert(
+            pdf_file, options=options, stream_response_to=output_file
+        )
+
+        assert isinstance(result, FileResult)
+        assert result.success is True
+        assert result.status == "complete"
+        assert result.output_path == output_file
+        assert not result.error
+
+        # Verify the file exists and contains valid JSON
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+        assert data["status"] == "complete"
+        assert data["success"] is True
+        assert "markdown" in data
+
+    def test_convert_normal_path_unchanged(self):
+        """Test that convert without stream_response_to still returns ConversionResult"""
+        client = DatalabClient()
+        pdf_file = DATA_DIR / "adversarial.pdf"
+
+        options = ConvertOptions(max_pages=1)
+        result = client.convert(pdf_file, options=options)
+
+        assert isinstance(result, ConversionResult)
+        assert result.success is True
+        assert result.markdown is not None
+
+    def test_save_output_and_stream_response_to_mutually_exclusive(self):
+        """Test that using both save_output and stream_response_to raises ValueError"""
+        client = DatalabClient()
+        pdf_file = DATA_DIR / "adversarial.pdf"
+
+        with pytest.raises(ValueError, match="Cannot use both"):
+            client.convert(
+                pdf_file,
+                save_output="/tmp/out",
+                stream_response_to="/tmp/stream.json",
+            )
+
+    def test_stream_response_to_invalid_directory(self):
+        """Test that a non-existent parent directory raises ValueError"""
+        client = DatalabClient()
+        pdf_file = DATA_DIR / "adversarial.pdf"
+
+        with pytest.raises(ValueError, match="Directory does not exist"):
+            client.convert(
+                pdf_file,
+                stream_response_to="/nonexistent/dir/result.json",
+            )
+
+    @pytest.mark.asyncio
+    async def test_convert_stream_async(self, tmp_path):
+        """Test async convert with stream_response_to"""
+        async with AsyncDatalabClient() as client:
+            pdf_file = DATA_DIR / "adversarial.pdf"
+            output_file = tmp_path / "async_result.json"
+
+            options = ConvertOptions(max_pages=1)
+            result = await client.convert(
+                pdf_file, options=options, stream_response_to=output_file
+            )
+
+            assert isinstance(result, FileResult)
+            assert result.success is True
+            assert result.status == "complete"
+            assert output_file.exists()
+
+            data = json.loads(output_file.read_text())
+            assert data["status"] == "complete"
+
+    def test_convert_stream_html_format(self, tmp_path):
+        """Test streaming with HTML output format"""
+        client = DatalabClient()
+        pdf_file = DATA_DIR / "adversarial.pdf"
+        output_file = tmp_path / "result.json"
+
+        options = ConvertOptions(output_format="html", max_pages=1)
+        result = client.convert(
+            pdf_file, options=options, stream_response_to=output_file
+        )
+
+        assert isinstance(result, FileResult)
+        assert result.success is True
+        assert output_file.exists()
+
+        data = json.loads(output_file.read_text())
+        assert "html" in data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.12.14",
     "click>=8.2.1",
+    "ijson>=3.3.0",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",
     "tenacity>=8.2.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -212,14 +212,16 @@ wheels = [
 
 [[package]]
 name = "datalab-python-sdk"
-version = "0.1.14"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
+    { name = "ijson" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "tenacity" },
+    { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
@@ -237,9 +239,11 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.14" },
     { name = "click", specifier = ">=8.2.1" },
+    { name = "ijson", specifier = ">=3.3.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "tenacity", specifier = ">=8.2.3" },
+    { name = "tqdm", specifier = ">=4.66.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -429,6 +433,97 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "ijson"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/57/60d1a6a512f2f0508d0bc8b4f1cc5616fd3196619b66bd6a01f9155a1292/ijson-3.5.0.tar.gz", hash = "sha256:94688760720e3f5212731b3cb8d30267f9a045fb38fb3870254e7b9504246f31", size = 68658, upload-time = "2026-02-24T03:58:30.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/32/21c1b47a1afb7319944d0b9685c0997a9d574a77b030c82f6a1ac2cef4eb/ijson-3.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ea8dcac10d86adaeead454bc25c97b68d0bda573d5fd6f86f5e21cf8f7906f88", size = 88935, upload-time = "2026-02-24T03:56:40.591Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f7/6ac7ebbb3cd767c87cdcbb950a6754afd1c0977756347bfe03eb8e5b866d/ijson-3.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:92b0495bbb2150bbf14fc5d98fb6d76bcd1c526605a172709e602e6fedc96495", size = 60567, upload-time = "2026-02-24T03:56:41.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/98/1140de9ae872468a8bc2e87c171228e25e58b1eb696b7fb430f7590fea44/ijson-3.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7af0c4c8943be8b09a4e57bdc1da6001dae7b36526d4154fe5c8224738d0921f", size = 60620, upload-time = "2026-02-24T03:56:42.764Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e1/67dfe0774e4c7ca6ec8702e280e8764d356f3db54358999818cda6df7679/ijson-3.5.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:45887d5e84ff0d2b138c926cebd9071830733968afe8d9d12080b3c178c7f918", size = 126558, upload-time = "2026-02-24T03:56:43.922Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ef/23d614fc773d428caeb6e197218b7e32adcc668ff5b98777039149571208/ijson-3.5.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a70b575be8e57a28c80e90ed349ad3a851c3478524c70e36e07d6092ecd12c9", size = 133091, upload-time = "2026-02-24T03:56:45.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/80/99727603cd8a1d32edafa4392f4056b2420bf48c15afd34481c68a2d4435/ijson-3.5.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2adeecd45830bfd5580ca79a584154713aabef0b9607e16249133df5d2859813", size = 130249, upload-time = "2026-02-24T03:56:46.333Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/94/3a3d623ca80768e834be8a834ef05960e3b9e79af1a911704ff10c9e8792/ijson-3.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d873e72889e7fc5962ab58909f1adff338d7c2f49e450e5b5fe844eff8155a14", size = 133501, upload-time = "2026-02-24T03:56:47.54Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f6/df2c14ad340834eccee379046f155e4b66a16ddafd445429dee7b3323614/ijson-3.5.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9a88c559456a79708592234d697645d92b599718f4cbbeaa6515f83ac63ca0ae", size = 128438, upload-time = "2026-02-24T03:56:48.455Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7e/9ff5b8b5fee113f5607bc4149b707382a898eeb545153189b075e5ec8d59/ijson-3.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cf83f58ad50dc0d39a2105cb26d4f359b38f42cef68b913170d4d47d97d97ba5", size = 131116, upload-time = "2026-02-24T03:56:49.737Z" },
+    { url = "https://files.pythonhosted.org/packages/64/20/954ce0d440d7cf72a3d8361b14406f9cdbf624b1625c10f8488857c769d6/ijson-3.5.0-cp310-cp310-win32.whl", hash = "sha256:aec4580a7712a19b1f95cd41bed260fc6a31266d37ef941827772a4c199e8143", size = 52724, upload-time = "2026-02-24T03:56:50.932Z" },
+    { url = "https://files.pythonhosted.org/packages/24/33/ece87d60502c6115642cbabeb8c122fa982212b392bc4f4ff5aab8e02dac/ijson-3.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:9a9c4c70501e23e8eb1675330686d1598eebfa14b6f0dbc8f00c2e081cc628fa", size = 55125, upload-time = "2026-02-24T03:56:51.942Z" },
+    { url = "https://files.pythonhosted.org/packages/65/da/644343198abca5e0f6e2486063f8d8f3c443ca0ef5e5c890e51ef6032e33/ijson-3.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5616311404b858d32740b7ad8b9a799c62165f5ecb85d0a8ed16c21665a90533", size = 88964, upload-time = "2026-02-24T03:56:53.099Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/63/8621190aa2baf96156dfd4c632b6aa9f1464411e50b98750c09acc0505ea/ijson-3.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e9733f94029dd41702d573ef64752e2556e72aea14623d6dbb7a44ca1ccf30fd", size = 60582, upload-time = "2026-02-24T03:56:54.261Z" },
+    { url = "https://files.pythonhosted.org/packages/20/31/6a3f041fdd17dacff33b7d7d3ba3df6dca48740108340c6042f974b2ad20/ijson-3.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db8398c6721b98412a4f618da8022550c8b9c5d9214040646071b5deb4d4a393", size = 60632, upload-time = "2026-02-24T03:56:55.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/68/474541998abbdecfd46a744536878335de89aceb9f085bff1aaf35575ceb/ijson-3.5.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c061314845c08163b1784b6076ea5f075372461a32e6916f4e5f211fd4130b64", size = 131988, upload-time = "2026-02-24T03:56:56.35Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/32/e05ff8b72a44fe9d192f41c5dcbc35cfa87efc280cdbfe539ffaf4a7535e/ijson-3.5.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1111a1c5ac79119c5d6e836f900c1a53844b50a18af38311baa6bb61e2645aca", size = 138669, upload-time = "2026-02-24T03:56:57.555Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b5/955a83b031102c7a602e2c06d03aff0a0e584212f09edb94ccc754d203ac/ijson-3.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e74aff8c681c24002b61b1822f9511d4c384f324f7dbc08c78538e01fdc9fcb", size = 135093, upload-time = "2026-02-24T03:56:59.267Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f2/30250cfcb4d2766669b31f6732689aab2bb91de426a15a3ebe482df7ee48/ijson-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:739a7229b1b0cc5f7e2785a6e7a5fc915e850d3fed9588d0e89a09f88a417253", size = 138715, upload-time = "2026-02-24T03:57:00.491Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/05/785a145d7e75e04e04480d59b6323cd4b1d9013a6cd8643fa635fbc93490/ijson-3.5.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ef88712160360cab3ca6471a4e5418243f8b267cf1fe1620879d1b5558babc71", size = 133194, upload-time = "2026-02-24T03:57:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/14/eb/80d6f8a748dead4034cea0939494a67d10ccf88d6413bf6e860393139676/ijson-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6ca0d1b6b5f8166a6248f4309497585fb8553b04bc8179a0260fad636cfdb798", size = 135588, upload-time = "2026-02-24T03:57:03.131Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a8/bbc21f9400ebdbca48fab272593e0d1f875691be1e927d264d90d48b8c47/ijson-3.5.0-cp311-cp311-win32.whl", hash = "sha256:966039cf9047c7967febf7b9a52ec6f38f5464a4c7fbb5565e0224b7376fefff", size = 52721, upload-time = "2026-02-24T03:57:04.365Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2e/4e8c0208b8f920ee80c88c956f93e78318f2cfb646455353b182738b490c/ijson-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:6bad6a1634cb7c9f3f4c7e52325283b35b565f5b6cc27d42660c6912ce883422", size = 55121, upload-time = "2026-02-24T03:57:05.498Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/17/9c63c7688025f3a8c47ea717b8306649c8c7244e49e20a2be4e3515dc75c/ijson-3.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1ebefbe149a6106cc848a3eaf536af51a9b5ccc9082de801389f152dba6ab755", size = 88536, upload-time = "2026-02-24T03:57:06.809Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/dd/e15c2400244c117b06585452ebc63ae254f5a6964f712306afd1422daae0/ijson-3.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:19e30d9f00f82e64de689c0b8651b9cfed879c184b139d7e1ea5030cec401c21", size = 60499, upload-time = "2026-02-24T03:57:09.155Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a9/bf4fe3538a0c965f16b406f180a06105b875da83f0743e36246be64ef550/ijson-3.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a04a33ee78a6f27b9b8528c1ca3c207b1df3b8b867a4cf2fcc4109986f35c227", size = 60330, upload-time = "2026-02-24T03:57:10.574Z" },
+    { url = "https://files.pythonhosted.org/packages/31/76/6f91bdb019dd978fce1bc5ea1cd620cfc096d258126c91db2c03a20a7f34/ijson-3.5.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7d48dc2984af02eb3c56edfb3f13b3f62f2f3e4fe36f058c8cfc75d93adf4fed", size = 138977, upload-time = "2026-02-24T03:57:11.932Z" },
+    { url = "https://files.pythonhosted.org/packages/11/be/bbc983059e48a54b0121ee60042979faed7674490bbe7b2c41560db3f436/ijson-3.5.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1e73a44844d9adbca9cf2c4132cd875933e83f3d4b23881fcaf82be83644c7d", size = 149785, upload-time = "2026-02-24T03:57:13.255Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/2fee58f9024a3449aee83edfa7167fb5ccd7e1af2557300e28531bb68e16/ijson-3.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7389a56b8562a19948bdf1d7bae3a2edc8c7f86fb59834dcb1c4c722818e645a", size = 149729, upload-time = "2026-02-24T03:57:14.191Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/56/f1706761fcc096c9d414b3dcd000b1e6e5c24364c21cfba429837f98ee8d/ijson-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3176f23f8ebec83f374ed0c3b4e5a0c4db7ede54c005864efebbed46da123608", size = 150697, upload-time = "2026-02-24T03:57:15.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/6e/ee0d9c875a0193b632b3e9ccd1b22a50685fb510256ad57ba483b6529f77/ijson-3.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6babd88e508630c6ef86c9bebaaf13bb2fb8ec1d8f8868773a03c20253f599bc", size = 142873, upload-time = "2026-02-24T03:57:16.831Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/bf/f9d4399d0e6e3fd615035290a71e97c843f17f329b43638c0a01cf112d73/ijson-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dc1b3836b174b6db2fa8319f1926fb5445abd195dc963368092103f8579cb8ed", size = 151583, upload-time = "2026-02-24T03:57:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/a7254a065933c0e2ffd3586f46187d84830d3d7b6f41cfa5901820a4f87d/ijson-3.5.0-cp312-cp312-win32.whl", hash = "sha256:6673de9395fb9893c1c79a43becd8c8fbee0a250be6ea324bfd1487bb5e9ee4c", size = 53079, upload-time = "2026-02-24T03:57:18.703Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7b/2edca79b359fc9f95d774616867a03ecccdf333797baf5b3eea79733918c/ijson-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f4f7fabd653459dcb004175235f310435959b1bb5dfa8878578391c6cc9ad944", size = 55500, upload-time = "2026-02-24T03:57:20.428Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/d67e764a712c3590627480643a3b51efcc3afa4ef3cb54ee4c989073c97e/ijson-3.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e9cedc10e40dd6023c351ed8bfc7dcfce58204f15c321c3c1546b9c7b12562a4", size = 88544, upload-time = "2026-02-24T03:57:21.293Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/39/f1c299371686153fa3cf5c0736b96247a87a1bee1b7145e6d21f359c505a/ijson-3.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3647649f782ee06c97490b43680371186651f3f69bebe64c6083ee7615d185e5", size = 60495, upload-time = "2026-02-24T03:57:22.501Z" },
+    { url = "https://files.pythonhosted.org/packages/16/94/b1438e204d75e01541bebe3e668fe3e68612d210e9931ae1611062dd0a56/ijson-3.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:90e74be1dce05fce73451c62d1118671f78f47c9f6be3991c82b91063bf01fc9", size = 60325, upload-time = "2026-02-24T03:57:23.332Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e2/4aa9c116fa86cc8b0f574f3c3a47409edc1cd4face05d0e589a5a176b05d/ijson-3.5.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:78e9ad73e7be2dd80627504bd5cbf512348c55ce2c06e362ed7683b5220e8568", size = 138774, upload-time = "2026-02-24T03:57:24.683Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d2/738b88752a70c3be1505faa4dcd7110668c2712e582a6a36488ed1e295d4/ijson-3.5.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9577449313cc94be89a4fe4b3e716c65f09cc19636d5a6b2861c4e80dddebd58", size = 149820, upload-time = "2026-02-24T03:57:26.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/df/0b3ab9f393ca8f72ea03bc896ba9fdc987e90ae08cdb51c32a4ee0c14d5e/ijson-3.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e4c1178fb50aff5f5701a30a5152ead82a14e189ce0f6102fa1b5f10b2f54ff", size = 149747, upload-time = "2026-02-24T03:57:27.308Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a3/b0037119f75131b78cb00acc2657b1a9d0435475f1f2c5f8f5a170b66b9c/ijson-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0eb402ab026ffb37a918d75af2b7260fe6cfbce13232cc83728a714dd30bd81d", size = 151027, upload-time = "2026-02-24T03:57:28.522Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a0/cb344de1862bf09d8f769c9d25c944078c87dd59a1b496feec5ad96309a4/ijson-3.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5b08ee08355f9f729612a8eb9bf69cc14f9310c3b2a487c6f1c3c65d85216ec4", size = 142996, upload-time = "2026-02-24T03:57:29.774Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/32/a8ffd67182e02ea61f70f62daf43ded4fa8a830a2520a851d2782460aba8/ijson-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bda62b6d48442903e7bf56152108afb7f0f1293c2b9bef2f2c369defea76ab18", size = 152068, upload-time = "2026-02-24T03:57:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/3578df8e75d446aab0ae92e27f641341f586b85e1988536adebc65300cb4/ijson-3.5.0-cp313-cp313-win32.whl", hash = "sha256:8d073d9b13574cfa11083cc7267c238b7a6ed563c2661e79192da4a25f09c82c", size = 53065, upload-time = "2026-02-24T03:57:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a2/f7cdaf5896710da3e69e982e44f015a83d168aa0f3a89b6f074b5426779d/ijson-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:2419f9e32e0968a876b04d8f26aeac042abd16f582810b576936bbc4c6015069", size = 55499, upload-time = "2026-02-24T03:57:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/13e2492d17e19a2084523e18716dc2809159f2287fd2700c735f311e76c4/ijson-3.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4d4b0cd676b8c842f7648c1a783448fac5cd3b98289abd83711b3e275e143524", size = 93019, upload-time = "2026-02-24T03:57:33.976Z" },
+    { url = "https://files.pythonhosted.org/packages/33/92/483fc97ece0c3f1cecabf48f6a7a36e89d19369eec462faaeaa34c788992/ijson-3.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:252dec3680a48bb82d475e36b4ae1b3a9d7eb690b951bb98a76c5fe519e30188", size = 62714, upload-time = "2026-02-24T03:57:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/88/793fe020a0fe9d9eed4c285cf4a5cfdb0a935708b3bde0d72f35c794b513/ijson-3.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:aa1b5dca97d323931fde2501172337384c958914d81a9dac7f00f0d4bfc76bc7", size = 62460, upload-time = "2026-02-24T03:57:35.874Z" },
+    { url = "https://files.pythonhosted.org/packages/51/69/f1a2690aa8d4df1f4e262b385e65a933ffdc250b091531bac9a449c19e16/ijson-3.5.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7a5ec7fd86d606094bba6f6f8f87494897102fa4584ef653f3005c51a784c320", size = 199273, upload-time = "2026-02-24T03:57:37.07Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a2/f1346d5299e79b988ab472dc773d5381ec2d57c23cb2f1af3ede4a810e62/ijson-3.5.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:009f41443e1521847701c6d87fa3923c0b1961be3c7e7de90947c8cb92ea7c44", size = 216884, upload-time = "2026-02-24T03:57:38.346Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3c/8b637e869be87799e6c2c3c275a30a546f086b1aed77e2b7f11512168c5a/ijson-3.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4c3651d1f9fe2839a93fdf8fd1d5ca3a54975349894249f3b1b572bcc4bd577", size = 207306, upload-time = "2026-02-24T03:57:39.718Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7c/18b1c1df6951ca056782d7580ec40cea4ff9a27a0947d92640d1cc8c4ae3/ijson-3.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:945b7abcfcfeae2cde17d8d900870f03536494245dda7ad4f8d056faa303256c", size = 211364, upload-time = "2026-02-24T03:57:40.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/55/e795812e82851574a9dba8a53fde045378f531ef14110c6fb55dbd23b443/ijson-3.5.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0574b0a841ff97495c13e9d7260fbf3d85358b061f540c52a123db9dbbaa2ed6", size = 200608, upload-time = "2026-02-24T03:57:42.272Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/cd/013c85b4749b57a4cb4c2670014d1b32b8db4ab1a7be92ea7aeb5d7fe7b5/ijson-3.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f969ffb2b89c5cdf686652d7fb66252bc72126fa54d416317411497276056a18", size = 205127, upload-time = "2026-02-24T03:57:43.286Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7c/faf643733e3ab677f180018f6a855c4ef70b7c46540987424c563c959e42/ijson-3.5.0-cp313-cp313t-win32.whl", hash = "sha256:59d3f9f46deed1332ad669518b8099920512a78bda64c1f021fcd2aff2b36693", size = 55282, upload-time = "2026-02-24T03:57:44.353Z" },
+    { url = "https://files.pythonhosted.org/packages/69/22/94ddb47c24b491377aca06cd8fc9202cad6ab50619842457d2beefde21ea/ijson-3.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5c2839fa233746d8aad3b8cd2354e441613f5df66d721d59da4a09394bd1db2b", size = 58016, upload-time = "2026-02-24T03:57:45.237Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/93/0868efe753dc1df80cc405cf0c1f2527a6991643607c741bff8dcb899b3b/ijson-3.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:25a5a6b2045c90bb83061df27cfa43572afa43ba9408611d7bfe237c20a731a9", size = 89094, upload-time = "2026-02-24T03:57:46.115Z" },
+    { url = "https://files.pythonhosted.org/packages/24/94/fd5a832a0df52ef5e4e740f14ac8640725d61034a1b0c561e8b5fb424706/ijson-3.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:8976c54c0b864bc82b951bae06567566ac77ef63b90a773a69cd73aab47f4f4f", size = 60715, upload-time = "2026-02-24T03:57:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/70/79/1b9a90af5732491f9eec751ee211b86b11011e1158c555c06576d52c3919/ijson-3.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:859eb2038f7f1b0664df4241957694cc35e6295992d71c98659b22c69b3cbc10", size = 60638, upload-time = "2026-02-24T03:57:48.428Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6f/2c551ea980fe56f68710a8d5389cfbd015fc45aaafd17c3c52c346db6aa1/ijson-3.5.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c911aa02991c7c0d3639b6619b93a93210ff1e7f58bf7225d613abea10adc78e", size = 140667, upload-time = "2026-02-24T03:57:49.314Z" },
+    { url = "https://files.pythonhosted.org/packages/25/0e/27b887879ba6a5bc29766e3c5af4942638c952220fd63e1e442674f7883a/ijson-3.5.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:903cbdc350173605220edc19796fbea9b2203c8b3951fb7335abfa8ed37afda8", size = 149850, upload-time = "2026-02-24T03:57:50.329Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1e/23e10e1bc04bf31193b21e2960dce14b17dbd5d0c62204e8401c59d62c08/ijson-3.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4549d96ded5b8efa71639b2160235415f6bdb8c83367615e2dbabcb72755c33", size = 149206, upload-time = "2026-02-24T03:57:51.261Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/90/e552f6495063b235cf7fa2c592f6597c057077195e517b842a0374fd470c/ijson-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6b2dcf6349e6042d83f3f8c39ce84823cf7577eba25bac5aae5e39bbbbbe9c1c", size = 150438, upload-time = "2026-02-24T03:57:52.198Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/18/45bf8f297c41b42a1c231d261141097babd953d2c28a07be57ae4c3a1a02/ijson-3.5.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e44af39e6f8a17e5627dcd89715d8279bf3474153ff99aae031a936e5c5572e5", size = 144369, upload-time = "2026-02-24T03:57:53.22Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/deb9772bb2c0cead7ad64f00c3598eec9072bdf511818e70e2c512eeabbe/ijson-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9260332304b7e7828db56d43f08fc970a3ab741bf84ff10189361ea1b60c395b", size = 151352, upload-time = "2026-02-24T03:57:54.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/51/67f4d80cd58ad7eab0cd1af5fe28b961886338956b2f88c0979e21914346/ijson-3.5.0-cp314-cp314-win32.whl", hash = "sha256:63bc8121bb422f6969ced270173a3fa692c29d4ae30c860a2309941abd81012a", size = 53610, upload-time = "2026-02-24T03:57:55.655Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d3/263672ea22983ba3940f1534316dbc9200952c1c2a2332d7a664e4eaa7ae/ijson-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:01b6dad72b7b7df225ef970d334556dfad46c696a2c6767fb5d9ed8889728bca", size = 56301, upload-time = "2026-02-24T03:57:56.584Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d9/86f7fac35e0835faa188085ae0579e813493d5261ce056484015ad533445/ijson-3.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2ea4b676ec98e374c1df400a47929859e4fa1239274339024df4716e802aa7e4", size = 93069, upload-time = "2026-02-24T03:57:57.849Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d2/e7366ed9c6e60228d35baf4404bac01a126e7775ea8ce57f560125ed190a/ijson-3.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:014586eec043e23c80be9a923c56c3a0920a0f1f7d17478ce7bc20ba443968ef", size = 62767, upload-time = "2026-02-24T03:57:58.758Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8b/3e703e8cc4b3ada79f13b28070b51d9550c578f76d1968657905857b2ddd/ijson-3.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5b8b886b0248652d437f66e7c5ac318bbdcb2c7137a7e5327a68ca00b286f5f", size = 62467, upload-time = "2026-02-24T03:58:00.261Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/0c91af32c1ee8a957fdac2e051b5780756d05fd34e4b60d94a08d51bac1d/ijson-3.5.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:498fd46ae2349297e43acf97cdc421e711dbd7198418677259393d2acdc62d78", size = 200447, upload-time = "2026-02-24T03:58:01.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/80/796ea0e391b7e2d45c5b1b451734bba03f81c2984cf955ea5eaa6c4920ad/ijson-3.5.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22a51b4f9b81f12793731cf226266d1de2112c3c04ba4a04117ad4e466897e05", size = 217820, upload-time = "2026-02-24T03:58:02.598Z" },
+    { url = "https://files.pythonhosted.org/packages/38/14/52b6613fdda4078c62eb5b4fe3efc724ddc55a4ad524c93de51830107aa3/ijson-3.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9636c710dc4ac4a281baa266a64f323b4cc165cec26836af702c44328b59a515", size = 208310, upload-time = "2026-02-24T03:58:04.759Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ad/8b3105a78774fd4a65e534a21d975ef3a77e189489fe3029ebcaeba5e243/ijson-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f7168a39e8211107666d71b25693fd1b2bac0b33735ef744114c403c6cac21e1", size = 211843, upload-time = "2026-02-24T03:58:05.836Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/a2739f6072d6e1160581bc3ed32da614c8cced023dcd519d9c5fa66e0425/ijson-3.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8696454245415bc617ab03b0dc3ae4c86987df5dc6a90bad378fe72c5409d89e", size = 200906, upload-time = "2026-02-24T03:58:07.788Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/5e/e06c2de3c3d4a9cfb655c1ad08a68fb72838d271072cdd3196576ac4431a/ijson-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c21bfb61f71f191565885bf1bc29e0a186292d866b4880637b833848360bdc1b", size = 205495, upload-time = "2026-02-24T03:58:09.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/11/778201eb2e202ddd76b36b0fb29bf3d8e3c167389d8aa883c62524e49f47/ijson-3.5.0-cp314-cp314t-win32.whl", hash = "sha256:a2619460d6795b70d0155e5bf016200ac8a63ab5397aa33588bb02b6c21759e6", size = 56280, upload-time = "2026-02-24T03:58:10.116Z" },
+    { url = "https://files.pythonhosted.org/packages/23/28/96711503245339084c8086b892c47415895eba49782d6cc52d9f4ee50301/ijson-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4f24b78d4ef028d17eb57ad1b16c0aed4a17bdd9badbf232dc5d9305b7e13854", size = 58965, upload-time = "2026-02-24T03:58:11.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3b/d31ecfa63a218978617446159f3d77aab2417a5bd2885c425b176353ff78/ijson-3.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:d64c624da0e9d692d6eb0ff63a79656b59d76bf80773a17c5b0f835e4e8ef627", size = 57715, upload-time = "2026-02-24T03:58:24.545Z" },
+    { url = "https://files.pythonhosted.org/packages/30/51/b170e646d378e8cccf9637c05edb5419b00c2c4df64b0258c3af5355608e/ijson-3.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:876f7df73b7e0d6474f9caa729b9cdbfc8e76de9075a4887dfd689e29e85c4ca", size = 57205, upload-time = "2026-02-24T03:58:25.681Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/83/44dbd0231b0a8c6c14d27473d10c4e27dfbce7d5d9a833c79e3e6c33eb40/ijson-3.5.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e7dbff2c8d9027809b0cde663df44f3210da10ea377121d42896fb6ee405dd31", size = 71229, upload-time = "2026-02-24T03:58:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/98/cf84048b7c6cec888826e696a31f45bee7ebcac15e532b6be1fc4c2c9608/ijson-3.5.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4217a1edc278660679e1197c83a1a2a2d367792bfbb2a3279577f4b59b93730d", size = 71217, upload-time = "2026-02-24T03:58:28.021Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0a/e34c729a87ff67dc6540f6bcc896626158e691d433ab57db0086d73decd2/ijson-3.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04f0fc740311388ee745ba55a12292b722d6f52000b11acbb913982ba5fbdf87", size = 68618, upload-time = "2026-02-24T03:58:28.918Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/0f/e849d072f2e0afe49627de3995fc9dae54b4c804c70c0840f928d95c10e1/ijson-3.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fdeee6957f92e0c114f65c55cf8fe7eabb80cfacab64eea6864060913173f66d", size = 55369, upload-time = "2026-02-24T03:58:29.839Z" },
 ]
 
 [[package]]
@@ -1100,6 +1195,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
…disk

Adds ijson-based incremental JSON parsing to stream poll responses to a temp file without loading them into memory. When complete, the temp file is atomically moved to the caller-specified path and a lightweight FileResult is returned. Supported on all 8 public methods (convert, extract, segment, run_custom_pipeline, track_changes, create_document, ocr, fill) in both async and sync clients.