### PR TITLE
add extraction_mode to ExtractOptions

### DIFF
--- a/datalab_sdk/models.py
+++ b/datalab_sdk/models.py
@@ -83,7 +83,8 @@ class ExtractOptions(ProcessingOptions):
     schema_id: Optional[str] = None  # ID of a saved extraction schema (e.g. sch_k8Hx9mP2nQ4v). Mutually exclusive with page_schema.
     schema_version: Optional[int] = None  # Version of the schema. Only valid with schema_id.
     checkpoint_id: Optional[str] = None  # From previous /convert with save_checkpoint=true
-    mode: str = "fast"  # fast, balanced, accurate
+    mode: str = "fast"  # Parse mode: fast, balanced, accurate
+    extraction_mode: Optional[str] = None  # Extraction mode: "balanced" (default) or "accurate"
     output_format: str = "markdown"  # markdown, json, html, chunks
     save_checkpoint: bool = False
     webhook_url: Optional[str] = None
@@ -94,6 +95,9 @@ class ExtractOptions(ProcessingOptions):
         # When using schema_id, suppress the empty default page_schema
         if self.schema_id and not self.page_schema:
             form_data.pop("page_schema", None)
+        # Only send extraction_mode if explicitly set
+        if self.extraction_mode is None:
+            form_data.pop("extraction_mode", None)
         return form_data
 
 


### PR DESCRIPTION
New parameter: extraction_mode ("balanced" or "accurate"). Controls the extraction pipeline independently from mode (which controls parsing). When not set, the API defaults to balanced.

Accurate mode returns per-field verification metadata including extraction_status, reasoning, citations, and verification feedback.